### PR TITLE
feat: add CLA bot workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA' || github.event_name == 'pull_request_target')
+        uses: contributor-assistant/github-action@v2.5.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_BOT_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/atgora-forum/.github/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: 'gxjansen,dependabot[bot],github-actions[bot]'
+          remote-organization-name: 'atgora-forum'
+          remote-repository-name: '.github'
+          lock-pullrequest-aftermerge: false
+          use-dco-flag: false


### PR DESCRIPTION
Adds automated CLA enforcement. External contributors must sign CLA before merge. Signatures stored centrally in .github repo.