### PR TITLE
feat(lexicons): add permission set and top-level descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ import { schemas } from "@barazo-forum/lexicons";
 // Array of LexiconDoc objects for all forum.barazo.* schemas
 ```
 
+### Permission Set (OAuth Scopes)
+
+The package includes a permission set lexicon for AT Protocol OAuth. When the protocol's permission set system is fully deployed, clients will request `include:forum.barazo.authForumAccess` as an OAuth scope instead of `transition:generic`.
+
+```typescript
+import { LEXICON_IDS } from "@barazo-forum/lexicons";
+
+LEXICON_IDS.AuthForumAccess // "forum.barazo.authForumAccess"
+```
+
+The permission set declares `repo` access for all four record collections. Blob permissions (for future media attachments) must be requested separately per the AT Protocol spec.
+
 ## Record Types
 
 | Lexicon ID | Description | Key Type |
@@ -72,6 +84,12 @@ import { schemas } from "@barazo-forum/lexicons";
 | `forum.barazo.topic.reply` | Reply to a topic (content, root ref, parent ref, community) | `tid` |
 | `forum.barazo.interaction.reaction` | Reaction to content (subject ref, type, community) | `tid` |
 | `forum.barazo.actor.preferences` | User preferences singleton (maturity level, muted words, blocked DIDs, cross-post defaults) | `literal:self` |
+
+## Permission Set
+
+| Lexicon ID | Description |
+|------------|-------------|
+| `forum.barazo.authForumAccess` | OAuth permission set granting repo access to all Barazo record collections |
 
 ## Development
 

--- a/lexicons/forum/barazo/actor/preferences.json
+++ b/lexicons/forum/barazo/actor/preferences.json
@@ -1,6 +1,7 @@
 {
   "lexicon": 1,
   "id": "forum.barazo.actor.preferences",
+  "description": "User-level moderation, safety, and cross-posting preferences. Portable across AppViews.",
   "defs": {
     "main": {
       "type": "record",

--- a/lexicons/forum/barazo/authForumAccess.json
+++ b/lexicons/forum/barazo/authForumAccess.json
@@ -1,0 +1,24 @@
+{
+  "lexicon": 1,
+  "id": "forum.barazo.authForumAccess",
+  "description": "Permission set for Barazo forum access. Grants ability to create topics, replies, and reactions, and manage user preferences.",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "title": "Barazo Forum",
+      "detail": "Create topics, replies, and reactions. Manage your forum preferences.",
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "repo",
+          "collection": [
+            "forum.barazo.topic.post",
+            "forum.barazo.topic.reply",
+            "forum.barazo.interaction.reaction",
+            "forum.barazo.actor.preferences"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/lexicons/forum/barazo/interaction/reaction.json
+++ b/lexicons/forum/barazo/interaction/reaction.json
@@ -1,6 +1,7 @@
 {
   "lexicon": 1,
   "id": "forum.barazo.interaction.reaction",
+  "description": "A reaction to a forum topic or reply, with configurable reaction types per community.",
   "defs": {
     "main": {
       "type": "record",

--- a/lexicons/forum/barazo/topic/post.json
+++ b/lexicons/forum/barazo/topic/post.json
@@ -1,6 +1,7 @@
 {
   "lexicon": 1,
   "id": "forum.barazo.topic.post",
+  "description": "A forum topic post with title, content, community attribution, and optional tags and content labels.",
   "defs": {
     "main": {
       "type": "record",

--- a/lexicons/forum/barazo/topic/reply.json
+++ b/lexicons/forum/barazo/topic/reply.json
@@ -1,6 +1,7 @@
 {
   "lexicon": 1,
   "id": "forum.barazo.topic.reply",
+  "description": "A reply to a forum topic or another reply, with threaded parent references and community attribution.",
   "defs": {
     "main": {
       "type": "record",

--- a/src/generated/lexicons.ts
+++ b/src/generated/lexicons.ts
@@ -213,6 +213,8 @@ export const schemaDict = {
   ForumBarazoActorPreferences: {
     lexicon: 1,
     id: 'forum.barazo.actor.preferences',
+    description:
+      'User-level moderation, safety, and cross-posting preferences. Portable across AppViews.',
     defs: {
       main: {
         type: 'record',
@@ -286,6 +288,32 @@ export const schemaDict = {
       },
     },
   },
+  ForumBarazoAuthForumAccess: {
+    lexicon: 1,
+    id: 'forum.barazo.authForumAccess',
+    description:
+      'Permission set for Barazo forum access. Grants ability to create topics, replies, and reactions, and manage user preferences.',
+    defs: {
+      main: {
+        type: 'permission-set',
+        title: 'Barazo Forum',
+        detail:
+          'Create topics, replies, and reactions. Manage your forum preferences.',
+        permissions: [
+          {
+            type: 'permission',
+            resource: 'repo',
+            collection: [
+              'forum.barazo.topic.post',
+              'forum.barazo.topic.reply',
+              'forum.barazo.interaction.reaction',
+              'forum.barazo.actor.preferences',
+            ],
+          },
+        ],
+      },
+    },
+  },
   ForumBarazoDefs: {
     lexicon: 1,
     id: 'forum.barazo.defs',
@@ -296,6 +324,8 @@ export const schemaDict = {
   ForumBarazoInteractionReaction: {
     lexicon: 1,
     id: 'forum.barazo.interaction.reaction',
+    description:
+      'A reaction to a forum topic or reply, with configurable reaction types per community.',
     defs: {
       main: {
         type: 'record',
@@ -338,6 +368,8 @@ export const schemaDict = {
   ForumBarazoTopicPost: {
     lexicon: 1,
     id: 'forum.barazo.topic.post',
+    description:
+      'A forum topic post with title, content, community attribution, and optional tags and content labels.',
     defs: {
       main: {
         type: 'record',
@@ -408,6 +440,8 @@ export const schemaDict = {
   ForumBarazoTopicReply: {
     lexicon: 1,
     id: 'forum.barazo.topic.reply',
+    description:
+      'A reply to a forum topic or another reply, with threaded parent references and community attribution.',
     defs: {
       main: {
         type: 'record',
@@ -499,6 +533,7 @@ export const ids = {
   ComAtprotoLabelDefs: 'com.atproto.label.defs',
   ComAtprotoRepoStrongRef: 'com.atproto.repo.strongRef',
   ForumBarazoActorPreferences: 'forum.barazo.actor.preferences',
+  ForumBarazoAuthForumAccess: 'forum.barazo.authForumAccess',
   ForumBarazoDefs: 'forum.barazo.defs',
   ForumBarazoInteractionReaction: 'forum.barazo.interaction.reaction',
   ForumBarazoTopicPost: 'forum.barazo.topic.post',

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,4 +43,5 @@ export const LEXICON_IDS = {
   TopicReply: "forum.barazo.topic.reply",
   Reaction: "forum.barazo.interaction.reaction",
   ActorPreferences: "forum.barazo.actor.preferences",
+  AuthForumAccess: "forum.barazo.authForumAccess",
 } as const;

--- a/tests/lexicon-schemas.test.ts
+++ b/tests/lexicon-schemas.test.ts
@@ -19,7 +19,7 @@ async function getAllLexiconFiles(dir: string): Promise<string[]> {
 describe("Lexicon JSON schema structure", () => {
   it("all lexicon files are valid JSON", async () => {
     const files = await getAllLexiconFiles(LEXICONS_DIR);
-    expect(files.length).toBeGreaterThanOrEqual(4);
+    expect(files.length).toBeGreaterThanOrEqual(5);
     for (const file of files) {
       await expect(loadJson(file)).resolves.toBeDefined();
     }
@@ -188,6 +188,52 @@ describe("forum.barazo.interaction.reaction lexicon", () => {
     const subject = props["subject"] as Record<string, unknown>;
     expect(subject["type"]).toBe("ref");
     expect(subject["ref"]).toBe("com.atproto.repo.strongRef");
+  });
+});
+
+describe("forum.barazo.authForumAccess lexicon", () => {
+  let schema: Record<string, unknown>;
+
+  it("loads successfully", async () => {
+    schema = (await loadJson(
+      join(LEXICONS_DIR, "authForumAccess.json"),
+    )) as Record<string, unknown>;
+    expect(schema["id"]).toBe("forum.barazo.authForumAccess");
+  });
+
+  it("has a top-level description", () => {
+    expect(schema["description"]).toBeTypeOf("string");
+    expect((schema["description"] as string).length).toBeGreaterThan(0);
+  });
+
+  it("defines a permission-set type", () => {
+    const defs = schema["defs"] as Record<string, unknown>;
+    const main = defs["main"] as Record<string, unknown>;
+    expect(main["type"]).toBe("permission-set");
+  });
+
+  it("has title and detail strings", () => {
+    const defs = schema["defs"] as Record<string, unknown>;
+    const main = defs["main"] as Record<string, unknown>;
+    expect(main["title"]).toBeTypeOf("string");
+    expect(main["detail"]).toBeTypeOf("string");
+  });
+
+  it("declares repo permissions for all Barazo record collections", () => {
+    const defs = schema["defs"] as Record<string, unknown>;
+    const main = defs["main"] as Record<string, unknown>;
+    const permissions = main["permissions"] as Record<string, unknown>[];
+    expect(permissions).toHaveLength(1);
+
+    const repoPerm = permissions[0] as Record<string, unknown>;
+    expect(repoPerm["type"]).toBe("permission");
+    expect(repoPerm["resource"]).toBe("repo");
+
+    const collections = repoPerm["collection"] as string[];
+    expect(collections).toContain("forum.barazo.topic.post");
+    expect(collections).toContain("forum.barazo.topic.reply");
+    expect(collections).toContain("forum.barazo.interaction.reaction");
+    expect(collections).toContain("forum.barazo.actor.preferences");
   });
 });
 

--- a/tests/type-generation.test.ts
+++ b/tests/type-generation.test.ts
@@ -51,6 +51,10 @@ describe("LEXICON_IDS constants", () => {
       "forum.barazo.actor.preferences",
     );
   });
+
+  it("has correct AuthForumAccess ID", () => {
+    expect(LEXICON_IDS.AuthForumAccess).toBe("forum.barazo.authForumAccess");
+  });
 });
 
 describe("generated schemas", () => {
@@ -67,6 +71,7 @@ describe("generated schemas", () => {
     expect(schemaIds).toContain("forum.barazo.topic.reply");
     expect(schemaIds).toContain("forum.barazo.interaction.reaction");
     expect(schemaIds).toContain("forum.barazo.actor.preferences");
+    expect(schemaIds).toContain("forum.barazo.authForumAccess");
   });
 });
 
@@ -88,6 +93,12 @@ describe("generated ids map", () => {
   it("maps ForumBarazoActorPreferences correctly", () => {
     expect(ids.ForumBarazoActorPreferences).toBe(
       "forum.barazo.actor.preferences",
+    );
+  });
+
+  it("maps ForumBarazoAuthForumAccess correctly", () => {
+    expect(ids.ForumBarazoAuthForumAccess).toBe(
+      "forum.barazo.authForumAccess",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Add `forum.barazo.authForumAccess` permission-set lexicon declaring OAuth repo scopes for all four record collections (topic.post, topic.reply, interaction.reaction, actor.preferences)
- Add top-level `description` fields to all record lexicons for discoverability on [lexicon.garden](https://lexicon.garden/) and AT Protocol tooling
- Update generated code (`schemaDict`, `ids`), exports (`LEXICON_IDS`), README, and tests

## Context

Discovered via [lexicon.garden](https://lexicon.garden/) that:
1. SkyTalk (`blue.skytalk.talk.*`) uses a `permissionSet` lexicon to declare OAuth scopes -- a pattern we should adopt
2. The lexicon.garden documentation guide recommends top-level `description` fields for discoverability

The permission set follows AT Protocol's `auth` prefix naming convention and prepares for migration from `transition:generic` to `include:forum.barazo.authForumAccess` when the protocol's permission set system goes live. Blob permissions are intentionally excluded per AT Protocol spec (must be requested separately).

## Changes

| File | Change |
|------|--------|
| `lexicons/forum/barazo/authForumAccess.json` | New permission-set lexicon |
| `lexicons/forum/barazo/topic/post.json` | Added top-level `description` |
| `lexicons/forum/barazo/topic/reply.json` | Added top-level `description` |
| `lexicons/forum/barazo/interaction/reaction.json` | Added top-level `description` |
| `lexicons/forum/barazo/actor/preferences.json` | Added top-level `description` |
| `src/generated/lexicons.ts` | Added schema + descriptions to `schemaDict` and `ids` |
| `src/index.ts` | Added `AuthForumAccess` to `LEXICON_IDS` |
| `tests/lexicon-schemas.test.ts` | Tests for permission-set structure |
| `tests/type-generation.test.ts` | Tests for new ID exports |
| `README.md` | Documented permission set usage |

## Cascading impact

None. Verified across all completed phases (through Phase 3 M4):
- OAuth scope string (`transition:generic`) is independent of lexicon permission sets
- Firehose `SUPPORTED_COLLECTIONS` only includes record types
- No existing code references `authForumAccess`
- Top-level descriptions are purely additive metadata

## Test plan

- [x] All 74 tests pass (`pnpm test`)
- [x] TypeScript strict typecheck clean (`pnpm typecheck`)
- [x] ESLint clean (`pnpm lint`)
- [ ] CI passes on PR