### PR TITLE
📝 docs: rewrite README with comprehensive schema reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,95 @@
-# @barazo-forum/lexicons
+# Barazo Lexicons
 
-AT Protocol lexicon schemas and generated TypeScript types for the Barazo forum platform. Defines the `forum.barazo.*` namespace with record types for topics, replies, reactions, and user preferences.
+AT Protocol lexicon schemas and generated TypeScript types for the Barazo forum platform.
 
-**Status:** Alpha -- All MVP lexicon schemas defined, published to GitHub Packages
+![Status: Alpha](https://img.shields.io/badge/status-alpha-orange)
 
 ## What is this?
 
-Lexicons are AT Protocol schemas that define the data model for Barazo forums. They specify what a topic, reply, reaction, and user preferences record looks like in the AT Protocol ecosystem. These schemas are the contract between the user's PDS (Personal Data Server) and the Barazo AppView, ensuring all forum data is portable and interoperable.
+[Lexicons](https://atproto.com/specs/lexicon) are the schema language of the AT Protocol. They define how data is structured, validated, and exchanged across the decentralized network. Every record stored on a user's PDS (Personal Data Server) must conform to a lexicon schema.
 
-This package provides:
+This package defines the `forum.barazo.*` namespace -- the data contract between a user's PDS and any Barazo AppView. Because the schemas live on the protocol layer, all forum data (topics, replies, reactions, preferences) is portable: users own their data and can move between AppViews without loss.
+
+The package provides:
+
 - JSON lexicon schema files (the source of truth)
 - Generated TypeScript types with type guards and validators
 - Zod validation schemas for runtime input validation
-- Lexicon IDs as constants
+- Lexicon ID constants
+
+## Lexicon Schemas
+
+| Lexicon ID | Description | Key |
+|---|---|---|
+| `forum.barazo.topic.post` | Forum topic with title, markdown content, community, category, tags, and optional self-labels | `tid` |
+| `forum.barazo.topic.reply` | Threaded reply to a topic or another reply, with root and parent references | `tid` |
+| `forum.barazo.interaction.reaction` | Reaction to a topic or reply (e.g., like, heart), scoped to a community's configured set | `tid` |
+| `forum.barazo.actor.preferences` | User-level moderation and safety preferences: maturity filter, muted words, blocked/muted accounts, cross-post defaults | `literal:self` |
+| `forum.barazo.authForumAccess` | OAuth permission set granting repo access to all Barazo record collections | -- |
+| `forum.barazo.defs` | Shared type definitions (reserved for future reusable types) | -- |
+
+## Package Exports
+
+### Generated Types
+
+```typescript
+import {
+  ForumBarazoTopicPost,
+  ForumBarazoTopicReply,
+  ForumBarazoInteractionReaction,
+  ForumBarazoActorPreferences,
+} from "@barazo-forum/lexicons";
+
+// Record type
+type Post = ForumBarazoTopicPost.Record;
+
+// Type guard
+if (ForumBarazoTopicPost.isRecord(record)) {
+  console.log(record.title);
+}
+
+// Lexicon validation
+const result = ForumBarazoTopicPost.validateRecord(record);
+```
+
+### Zod Validation Schemas
+
+```typescript
+import {
+  topicPostSchema,
+  topicReplySchema,
+  reactionSchema,
+  actorPreferencesSchema,
+} from "@barazo-forum/lexicons";
+
+const result = topicPostSchema.safeParse(input);
+if (result.success) {
+  // result.data is typed as TopicPostInput
+}
+```
+
+### Lexicon ID Constants
+
+```typescript
+import { LEXICON_IDS, ids } from "@barazo-forum/lexicons";
+
+LEXICON_IDS.TopicPost       // "forum.barazo.topic.post"
+LEXICON_IDS.TopicReply      // "forum.barazo.topic.reply"
+LEXICON_IDS.Reaction        // "forum.barazo.interaction.reaction"
+LEXICON_IDS.ActorPreferences // "forum.barazo.actor.preferences"
+LEXICON_IDS.AuthForumAccess // "forum.barazo.authForumAccess"
+```
+
+### Raw Lexicon Schemas
+
+```typescript
+import { schemas } from "@barazo-forum/lexicons";
+// Array of LexiconDoc objects for all forum.barazo.* schemas
+```
 
 ## Installation
 
-For npm consumers outside the workspace, configure GitHub Packages access in `.npmrc`:
+Configure GitHub Packages access in `.npmrc`:
 
 ```
 @barazo-forum:registry=https://npm.pkg.github.com
@@ -28,86 +101,13 @@ Then install:
 pnpm add @barazo-forum/lexicons
 ```
 
-For workspace consumers (`barazo-api`, `barazo-web`): already linked via pnpm workspace.
-
-## Usage
-
-### Generated Types
-
-```typescript
-import { ForumBarazoTopicPost } from "@barazo-forum/lexicons";
-
-// Type for a topic post record
-type Post = ForumBarazoTopicPost.Record;
-
-// Type guard
-if (ForumBarazoTopicPost.isRecord(record)) {
-  console.log(record.title);
-}
-
-// Validate against lexicon schema
-const result = ForumBarazoTopicPost.validateRecord(record);
-```
-
-### Zod Validation
-
-```typescript
-import { topicPostSchema } from "@barazo-forum/lexicons";
-
-const result = topicPostSchema.safeParse(input);
-if (result.success) {
-  // result.data is typed as TopicPostInput
-}
-```
-
-### Lexicon IDs
-
-```typescript
-import { LEXICON_IDS, ids } from "@barazo-forum/lexicons";
-
-LEXICON_IDS.TopicPost // "forum.barazo.topic.post"
-ids.ForumBarazoTopicPost // "forum.barazo.topic.post"
-```
-
-### Raw Lexicon Schemas
-
-```typescript
-import { schemas } from "@barazo-forum/lexicons";
-// Array of LexiconDoc objects for all forum.barazo.* schemas
-```
-
-### Permission Set (OAuth Scopes)
-
-The package includes a permission set lexicon for AT Protocol OAuth. When the protocol's permission set system is fully deployed, clients will request `include:forum.barazo.authForumAccess` as an OAuth scope instead of `transition:generic`.
-
-```typescript
-import { LEXICON_IDS } from "@barazo-forum/lexicons";
-
-LEXICON_IDS.AuthForumAccess // "forum.barazo.authForumAccess"
-```
-
-The permission set declares `repo` access for all four record collections. Blob permissions (for future media attachments) must be requested separately per the AT Protocol spec.
-
-## Record Types
-
-| Lexicon ID | Description | Key Type |
-|------------|-------------|----------|
-| `forum.barazo.topic.post` | Forum topic/thread (title, content, community, category, tags, labels) | `tid` |
-| `forum.barazo.topic.reply` | Reply to a topic (content, root ref, parent ref, community) | `tid` |
-| `forum.barazo.interaction.reaction` | Reaction to content (subject ref, type, community) | `tid` |
-| `forum.barazo.actor.preferences` | User preferences singleton (maturity level, muted words, blocked DIDs, cross-post defaults) | `literal:self` |
-
-## Permission Set
-
-| Lexicon ID | Description |
-|------------|-------------|
-| `forum.barazo.authForumAccess` | OAuth permission set granting repo access to all Barazo record collections |
+Workspace consumers (`barazo-api`, `barazo-web`) are already linked via pnpm workspace.
 
 ## Development
 
 ```bash
 pnpm install
-pnpm test          # Run tests
+pnpm test          # Run tests (74 tests across 3 suites)
 pnpm build         # Compile TypeScript
 pnpm generate      # Regenerate types from lexicon JSON
 pnpm lint          # Lint
@@ -116,10 +116,10 @@ pnpm typecheck     # Type check
 
 ## Related Repositories
 
-- **[barazo-api](https://github.com/barazo-forum/barazo-api)** -- Backend (AGPL-3.0)
-- **[barazo-web](https://github.com/barazo-forum/barazo-web)** -- Frontend (MIT)
-- **[barazo-deploy](https://github.com/barazo-forum/barazo-deploy)** -- Deployment templates (MIT)
-- **[Organization](https://github.com/barazo-forum)** -- All repos
+- [barazo-api](https://github.com/barazo-forum/barazo-api) -- AppView backend (AGPL-3.0)
+- [barazo-web](https://github.com/barazo-forum/barazo-web) -- Forum frontend (MIT)
+- [barazo-deploy](https://github.com/barazo-forum/barazo-deploy) -- Docker Compose deployment templates (MIT)
+- [barazo-forum](https://github.com/barazo-forum) -- GitHub organization
 
 ## License
 


### PR DESCRIPTION
## Summary
- Restructure README to lead with what the package provides and why lexicons matter
- Add schema reference table listing all six lexicon IDs with descriptions and key types
- Expand code examples to cover all four record types, Zod schemas, and ID constants

## Changes
- `README.md`: Full rewrite -- better structure, richer examples, concise installation section

## Test plan
- [ ] CI passes (lint, typecheck, tests)