### PR TITLE
test(compat): add backward compatibility test suite

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["tests/*.ts"],
+          allowDefaultProject: ["tests/*.ts", "tests/fixtures/*.ts"],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:fix": "eslint --fix src/ tests/",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:compat": "vitest run tests/backward-compatibility.test.ts",
     "test:coverage": "vitest run --coverage",
     "generate": "lex gen-server ./src/generated ./lexicons/**/*.json && node scripts/fixup-generated.js",
     "clean": "rm -rf dist"

--- a/tests/backward-compatibility.test.ts
+++ b/tests/backward-compatibility.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Backward Compatibility Test Suite
+ *
+ * Ensures that schema changes never break records already stored on user PDSes.
+ * This test suite enforces the rules from PRD section 9 (Backwards Compatibility Rules):
+ *
+ * - Fields can be added (optional only)
+ * - Fields cannot be removed
+ * - Field types cannot change
+ * - Required fields cannot become optional (or vice versa)
+ * - Breaking changes require a new lexicon ID
+ *
+ * How it works:
+ * 1. Baseline records (fixtures) represent data already on PDSes
+ * 2. Schema snapshots capture structural invariants (required fields, property names)
+ * 3. Tests validate baseline records against BOTH Zod schemas and lexicon validators
+ * 4. If any test fails after a schema change, the change is backward-incompatible
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  topicPostSchema,
+  topicReplySchema,
+  reactionSchema,
+  actorPreferencesSchema,
+} from "../src/validation/index.js";
+import {
+  ForumBarazoTopicPost,
+  ForumBarazoTopicReply,
+  ForumBarazoInteractionReaction,
+  ForumBarazoActorPreferences,
+} from "../src/generated/index.js";
+import {
+  topicPostMinimal,
+  topicPostFull,
+  topicReplyMinimal,
+  topicReplyFull,
+  reactionMinimal,
+  reactionFull,
+  actorPreferencesMinimal,
+  actorPreferencesFull,
+} from "./fixtures/baseline-records.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function loadLexiconJson(lexiconPath: string): Record<string, unknown> {
+  const fullPath = path.resolve(
+    import.meta.dirname,
+    "..",
+    "lexicons",
+    lexiconPath,
+  );
+  return JSON.parse(fs.readFileSync(fullPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function getRecordProperties(
+  lexicon: Record<string, unknown>,
+): Record<string, unknown> {
+  const defs = lexicon["defs"] as Record<string, unknown>;
+  const main = defs["main"] as Record<string, unknown>;
+  const record = main["record"] as Record<string, unknown>;
+  return record["properties"] as Record<string, unknown>;
+}
+
+function getRequiredFields(lexicon: Record<string, unknown>): string[] {
+  const defs = lexicon["defs"] as Record<string, unknown>;
+  const main = defs["main"] as Record<string, unknown>;
+  const record = main["record"] as Record<string, unknown>;
+  return record["required"] as string[];
+}
+
+// Adds $type to a record for lexicon validator (which requires it)
+function withType<T extends Record<string, unknown>>(
+  record: T,
+  type: string,
+): T & { $type: string } {
+  return { ...record, $type: type };
+}
+
+// ── Schema Structural Snapshots ─────────────────────────────────────
+// These capture the contract. If any of these change, a test will fail,
+// forcing the developer to consider backward compatibility implications.
+
+const SCHEMA_SNAPSHOTS = {
+  "forum.barazo.topic.post": {
+    requiredFields: ["title", "content", "community", "category", "createdAt"],
+    allProperties: [
+      "title",
+      "content",
+      "contentFormat",
+      "community",
+      "category",
+      "tags",
+      "labels",
+      "createdAt",
+    ],
+  },
+  "forum.barazo.topic.reply": {
+    requiredFields: ["content", "root", "parent", "community", "createdAt"],
+    allProperties: [
+      "content",
+      "contentFormat",
+      "root",
+      "parent",
+      "community",
+      "labels",
+      "createdAt",
+    ],
+  },
+  "forum.barazo.interaction.reaction": {
+    requiredFields: ["subject", "type", "community", "createdAt"],
+    allProperties: ["subject", "type", "community", "createdAt"],
+  },
+  "forum.barazo.actor.preferences": {
+    requiredFields: ["maturityLevel", "updatedAt"],
+    allProperties: [
+      "maturityLevel",
+      "mutedWords",
+      "blockedDids",
+      "mutedDids",
+      "crossPostDefaults",
+      "updatedAt",
+    ],
+  },
+} as const;
+
+// ── Baseline Record Validation (Zod) ────────────────────────────────
+
+describe("backward compatibility: Zod validation of baseline records", () => {
+  describe("forum.barazo.topic.post", () => {
+    it("validates minimal baseline record", () => {
+      const result = topicPostSchema.safeParse(topicPostMinimal);
+      expect(result.success).toBe(true);
+    });
+
+    it("validates full baseline record", () => {
+      const result = topicPostSchema.safeParse(topicPostFull);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("forum.barazo.topic.reply", () => {
+    it("validates minimal baseline record", () => {
+      const result = topicReplySchema.safeParse(topicReplyMinimal);
+      expect(result.success).toBe(true);
+    });
+
+    it("validates full baseline record", () => {
+      const result = topicReplySchema.safeParse(topicReplyFull);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("forum.barazo.interaction.reaction", () => {
+    it("validates minimal baseline record", () => {
+      const result = reactionSchema.safeParse(reactionMinimal);
+      expect(result.success).toBe(true);
+    });
+
+    it("validates full baseline record", () => {
+      const result = reactionSchema.safeParse(reactionFull);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("forum.barazo.actor.preferences", () => {
+    it("validates minimal baseline record", () => {
+      const result = actorPreferencesSchema.safeParse(actorPreferencesMinimal);
+      expect(result.success).toBe(true);
+    });
+
+    it("validates full baseline record", () => {
+      const result = actorPreferencesSchema.safeParse(actorPreferencesFull);
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+// ── Baseline Record Validation (Lexicon/AT Protocol) ────────────────
+
+describe("backward compatibility: lexicon validation of baseline records", () => {
+  describe("forum.barazo.topic.post", () => {
+    it("validates minimal baseline record", () => {
+      const result = ForumBarazoTopicPost.validateRecord(
+        withType(topicPostMinimal, "forum.barazo.topic.post"),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("validates full baseline record", () => {
+      const result = ForumBarazoTopicPost.validateRecord(
+        withType(topicPostFull, "forum.barazo.topic.post"),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("forum.barazo.topic.reply", () => {
+    it("validates minimal baseline record", () => {
+      const result = ForumBarazoTopicReply.validateRecord(
+        withType(topicReplyMinimal, "forum.barazo.topic.reply"),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("validates full baseline record", () => {
+      const result = ForumBarazoTopicReply.validateRecord(
+        withType(topicReplyFull, "forum.barazo.topic.reply"),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("forum.barazo.interaction.reaction", () => {
+    it("validates minimal baseline record", () => {
+      const result = ForumBarazoInteractionReaction.validateRecord(
+        withType(reactionMinimal, "forum.barazo.interaction.reaction"),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("validates full baseline record", () => {
+      const result = ForumBarazoInteractionReaction.validateRecord(
+        withType(reactionFull, "forum.barazo.interaction.reaction"),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("forum.barazo.actor.preferences", () => {
+    it("validates minimal baseline record", () => {
+      const result = ForumBarazoActorPreferences.validateRecord(
+        withType(actorPreferencesMinimal, "forum.barazo.actor.preferences"),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("validates full baseline record", () => {
+      const result = ForumBarazoActorPreferences.validateRecord(
+        withType(actorPreferencesFull, "forum.barazo.actor.preferences"),
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+// ── Schema Structural Invariants ────────────────────────────────────
+// These tests catch accidental changes to required fields, removed
+// properties, or changed field types.
+
+describe("backward compatibility: schema structural invariants", () => {
+  const lexiconFiles: Array<{
+    name: string;
+    path: string;
+    snapshot: (typeof SCHEMA_SNAPSHOTS)[keyof typeof SCHEMA_SNAPSHOTS];
+  }> = [
+    {
+      name: "forum.barazo.topic.post",
+      path: "forum/barazo/topic/post.json",
+      snapshot: SCHEMA_SNAPSHOTS["forum.barazo.topic.post"],
+    },
+    {
+      name: "forum.barazo.topic.reply",
+      path: "forum/barazo/topic/reply.json",
+      snapshot: SCHEMA_SNAPSHOTS["forum.barazo.topic.reply"],
+    },
+    {
+      name: "forum.barazo.interaction.reaction",
+      path: "forum/barazo/interaction/reaction.json",
+      snapshot: SCHEMA_SNAPSHOTS["forum.barazo.interaction.reaction"],
+    },
+    {
+      name: "forum.barazo.actor.preferences",
+      path: "forum/barazo/actor/preferences.json",
+      snapshot: SCHEMA_SNAPSHOTS["forum.barazo.actor.preferences"],
+    },
+  ];
+
+  for (const { name, path: lexPath, snapshot } of lexiconFiles) {
+    describe(name, () => {
+      const lexicon = loadLexiconJson(lexPath);
+
+      it("has not removed any required fields", () => {
+        const currentRequired = getRequiredFields(lexicon);
+        for (const field of snapshot.requiredFields) {
+          expect(
+            currentRequired,
+            `Required field "${field}" was removed from ${name}. ` +
+              "This breaks existing records that rely on this field being required. " +
+              "Use a new lexicon ID for breaking changes.",
+          ).toContain(field);
+        }
+      });
+
+      it("has not added new required fields", () => {
+        const currentRequired = getRequiredFields(lexicon);
+        for (const field of currentRequired) {
+          expect(
+            snapshot.requiredFields,
+            `New required field "${field}" was added to ${name}. ` +
+              "Existing records on PDSes don't have this field. " +
+              "New fields must be optional, or use a new lexicon ID.",
+          ).toContain(field);
+        }
+      });
+
+      it("has not removed any properties", () => {
+        const currentProperties = Object.keys(getRecordProperties(lexicon));
+        for (const prop of snapshot.allProperties) {
+          expect(
+            currentProperties,
+            `Property "${prop}" was removed from ${name}. ` +
+              "Existing records on PDSes may contain this field. " +
+              "Fields cannot be removed from published schemas.",
+          ).toContain(prop);
+        }
+      });
+
+      it("may have added new optional properties (allowed)", () => {
+        // This test documents that new properties were added.
+        // New properties are allowed as long as they are optional (not in required[]).
+        const currentProperties = Object.keys(getRecordProperties(lexicon));
+        const currentRequired = getRequiredFields(lexicon);
+        const newProperties = currentProperties.filter(
+          (p) => !snapshot.allProperties.includes(p),
+        );
+
+        for (const prop of newProperties) {
+          expect(
+            currentRequired,
+            `New property "${prop}" in ${name} is required. ` +
+              "New properties must be optional to maintain backward compatibility.",
+          ).not.toContain(prop);
+        }
+      });
+    });
+  }
+});
+
+// ── Forward Compatibility (extra fields) ────────────────────────────
+// AT Protocol records may contain extra fields (from future schema versions).
+// The lexicon validator must not reject records with unknown properties.
+
+describe("backward compatibility: records with extra unknown fields", () => {
+  it("lexicon validator accepts topic.post with extra fields", () => {
+    const record = withType(
+      { ...topicPostMinimal, futureField: "some-value", anotherNew: 42 },
+      "forum.barazo.topic.post",
+    );
+    const result = ForumBarazoTopicPost.validateRecord(record);
+    expect(result.success).toBe(true);
+  });
+
+  it("lexicon validator accepts topic.reply with extra fields", () => {
+    const record = withType(
+      { ...topicReplyMinimal, futureField: true },
+      "forum.barazo.topic.reply",
+    );
+    const result = ForumBarazoTopicReply.validateRecord(record);
+    expect(result.success).toBe(true);
+  });
+
+  it("lexicon validator accepts reaction with extra fields", () => {
+    const record = withType(
+      { ...reactionMinimal, futureField: ["a", "b"] },
+      "forum.barazo.interaction.reaction",
+    );
+    const result = ForumBarazoInteractionReaction.validateRecord(record);
+    expect(result.success).toBe(true);
+  });
+
+  it("lexicon validator accepts actor.preferences with extra fields", () => {
+    const record = withType(
+      { ...actorPreferencesMinimal, futureField: { nested: true } },
+      "forum.barazo.actor.preferences",
+    );
+    const result = ForumBarazoActorPreferences.validateRecord(record);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Field Type Stability ────────────────────────────────────────────
+// Ensures field types haven't changed in the lexicon JSON schemas.
+
+describe("backward compatibility: field type stability", () => {
+  const FIELD_TYPE_SNAPSHOTS: Record<
+    string,
+    { path: string; types: Record<string, string> }
+  > = {
+    "forum.barazo.topic.post": {
+      path: "forum/barazo/topic/post.json",
+      types: {
+        title: "string",
+        content: "string",
+        contentFormat: "string",
+        community: "string",
+        category: "string",
+        tags: "array",
+        labels: "union",
+        createdAt: "string",
+      },
+    },
+    "forum.barazo.topic.reply": {
+      path: "forum/barazo/topic/reply.json",
+      types: {
+        content: "string",
+        contentFormat: "string",
+        root: "ref",
+        parent: "ref",
+        community: "string",
+        labels: "union",
+        createdAt: "string",
+      },
+    },
+    "forum.barazo.interaction.reaction": {
+      path: "forum/barazo/interaction/reaction.json",
+      types: {
+        subject: "ref",
+        type: "string",
+        community: "string",
+        createdAt: "string",
+      },
+    },
+    "forum.barazo.actor.preferences": {
+      path: "forum/barazo/actor/preferences.json",
+      types: {
+        maturityLevel: "string",
+        mutedWords: "array",
+        blockedDids: "array",
+        mutedDids: "array",
+        crossPostDefaults: "ref",
+        updatedAt: "string",
+      },
+    },
+  };
+
+  for (const [name, { path: lexPath, types }] of Object.entries(
+    FIELD_TYPE_SNAPSHOTS,
+  )) {
+    describe(name, () => {
+      const lexicon = loadLexiconJson(lexPath);
+      const properties = getRecordProperties(lexicon);
+
+      for (const [field, expectedType] of Object.entries(types)) {
+        it(`field "${field}" remains type "${expectedType}"`, () => {
+          const prop = properties[field] as Record<string, unknown>;
+          expect(
+            prop["type"],
+            `Field "${field}" in ${name} changed type from "${expectedType}" to "${String(prop["type"])}". ` +
+              "Field types cannot change in published schemas.",
+          ).toBe(expectedType);
+        });
+      }
+    });
+  }
+});

--- a/tests/fixtures/baseline-records.ts
+++ b/tests/fixtures/baseline-records.ts
@@ -1,0 +1,102 @@
+/**
+ * Baseline records representing data already stored on user PDSes.
+ *
+ * These fixtures simulate records created with the current schema version.
+ * When schemas evolve (new optional fields, description changes, etc.),
+ * these records MUST continue to validate. If any baseline record fails
+ * validation after a schema change, the change is backward-incompatible
+ * and must be reverted or handled via a new lexicon ID.
+ *
+ * Each record type has:
+ * - A minimal record (only required fields)
+ * - A full record (all optional fields populated)
+ *
+ * DO NOT modify existing records in this file when adding new optional fields
+ * to schemas. Instead, create new fixture variants that include the new fields.
+ * The existing fixtures must remain unchanged to prove backward compatibility.
+ */
+
+const VALID_DID = "did:plc:abc123def456";
+const VALID_DATETIME = "2026-02-12T10:00:00.000Z";
+const VALID_STRONG_REF = {
+  uri: "at://did:plc:abc123/forum.barazo.topic.post/3jzfcijpj2z2a",
+  cid: "bafyreibouvacvqhc2vkwwtdkfynpcaoatmkde7uhrw47ne4gu63cnzc7yq",
+};
+
+// ── topic.post ──────────────────────────────────────────────────────
+
+export const topicPostMinimal = {
+  title: "My First Topic",
+  content: "Hello, this is the body of my first topic post.",
+  community: VALID_DID,
+  category: "general",
+  createdAt: VALID_DATETIME,
+};
+
+export const topicPostFull = {
+  title: "Full Featured Topic",
+  content: "This topic includes every optional field available at v0.1.0.",
+  contentFormat: "markdown" as const,
+  community: VALID_DID,
+  category: "announcements",
+  tags: ["release", "v1"],
+  labels: {
+    $type: "com.atproto.label.defs#selfLabels",
+    values: [{ val: "nudity" }],
+  },
+  createdAt: VALID_DATETIME,
+};
+
+// ── topic.reply ─────────────────────────────────────────────────────
+
+export const topicReplyMinimal = {
+  content: "Great post, thanks for sharing!",
+  root: VALID_STRONG_REF,
+  parent: VALID_STRONG_REF,
+  community: VALID_DID,
+  createdAt: VALID_DATETIME,
+};
+
+export const topicReplyFull = {
+  content: "This reply uses all optional fields available at v0.1.0.",
+  contentFormat: "markdown" as const,
+  root: VALID_STRONG_REF,
+  parent: VALID_STRONG_REF,
+  community: VALID_DID,
+  labels: {
+    $type: "com.atproto.label.defs#selfLabels",
+    values: [{ val: "graphic-media" }],
+  },
+  createdAt: VALID_DATETIME,
+};
+
+// ── interaction.reaction ────────────────────────────────────────────
+
+export const reactionMinimal = {
+  subject: VALID_STRONG_REF,
+  type: "like",
+  community: VALID_DID,
+  createdAt: VALID_DATETIME,
+};
+
+// Reaction has no optional fields beyond the required ones
+export const reactionFull = { ...reactionMinimal };
+
+// ── actor.preferences ───────────────────────────────────────────────
+
+export const actorPreferencesMinimal = {
+  maturityLevel: "safe" as const,
+  updatedAt: VALID_DATETIME,
+};
+
+export const actorPreferencesFull = {
+  maturityLevel: "all" as const,
+  mutedWords: ["spam", "crypto-scam"],
+  blockedDids: ["did:plc:blocked1", "did:plc:blocked2"],
+  mutedDids: ["did:plc:muted1"],
+  crossPostDefaults: {
+    bluesky: true,
+    frontpage: false,
+  },
+  updatedAt: VALID_DATETIME,
+};


### PR DESCRIPTION
## Summary
- Adds a backward compatibility test suite (61 tests) that validates schema changes never break existing PDS records
- Completes the last unchecked M1 acceptance criterion in prd-lexicons.md
- Adds `test:compat` npm script for targeted backward compatibility testing

## Changes
- `tests/backward-compatibility.test.ts` — 4 test groups: Zod baseline validation, lexicon baseline validation, schema structural invariants (required fields, property names, field types), and forward compatibility (extra unknown fields)
- `tests/fixtures/baseline-records.ts` — Frozen fixture records representing data already on PDSes (minimal + full variants for all 4 record types)
- `package.json` — Added `test:compat` script
- `eslint.config.js` — Extended `allowDefaultProject` to include `tests/fixtures/*.ts`

## Test plan
- [x] CI passes (lint, typecheck, build, tests)
- [x] All 135 tests pass (74 existing + 61 new)
- [x] `pnpm test:compat` runs only backward compatibility tests