### PR TITLE
ci: add staging deploy trigger on push to main

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,26 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  trigger-deploy:
+    name: Trigger Staging Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to barazo-deploy
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.DEPLOY_PAT }}
+          repository: barazo-forum/barazo-deploy
+          event-type: deploy-staging
+          client-payload: |
+            {
+              "trigger_repo": "barazo-lexicons",
+              "api_ref": "main",
+              "web_ref": "main"
+            }


### PR DESCRIPTION
## Summary

- Fires `repository_dispatch` to `barazo-deploy` when lexicon changes are merged to main
- Triggers a rebuild of both API and Web images since both depend on lexicons

## Test plan

- [ ] CI passes
- [ ] Merging a lexicon change triggers a staging deploy