### PR TITLE
ci: add Dependabot monitoring for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+  # Keep GitHub Actions pinned SHAs up-to-date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+
   # Enable security updates for npm dependencies
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## Summary

- Adds `github-actions` package ecosystem to Dependabot config
- Dependabot will now auto-create PRs when pinned action SHAs have newer versions available
- Matches the config already present in barazo-deploy

## Test plan

- [ ] CI passes
- [ ] Verify Dependabot picks up the config (PRs should appear within ~24h if any actions are outdated)