### PR TITLE
fix(lexicons): change enum to knownValues for forward compatibility

### DIFF
--- a/lexicons/forum/barazo/actor/preferences.json
+++ b/lexicons/forum/barazo/actor/preferences.json
@@ -13,7 +13,7 @@
         "properties": {
           "maturityLevel": {
             "type": "string",
-            "enum": ["safe", "mature", "all"],
+            "knownValues": ["safe", "mature", "all"],
             "description": "Maximum maturity tier to show. Default: 'safe'."
           },
           "mutedWords": {

--- a/lexicons/forum/barazo/topic/post.json
+++ b/lexicons/forum/barazo/topic/post.json
@@ -26,7 +26,7 @@
           },
           "contentFormat": {
             "type": "string",
-            "enum": ["markdown"],
+            "knownValues": ["markdown"],
             "description": "Content format. Defaults to 'markdown' if omitted."
           },
           "community": {

--- a/lexicons/forum/barazo/topic/reply.json
+++ b/lexicons/forum/barazo/topic/reply.json
@@ -19,7 +19,7 @@
           },
           "contentFormat": {
             "type": "string",
-            "enum": ["markdown"],
+            "knownValues": ["markdown"],
             "description": "Content format. Defaults to 'markdown' if omitted."
           },
           "root": {

--- a/src/generated/lexicons.ts
+++ b/src/generated/lexicons.ts
@@ -227,7 +227,7 @@ export const schemaDict = {
           properties: {
             maturityLevel: {
               type: 'string',
-              enum: ['safe', 'mature', 'all'],
+              knownValues: ['safe', 'mature', 'all'],
               description: "Maximum maturity tier to show. Default: 'safe'.",
             },
             mutedWords: {
@@ -394,7 +394,7 @@ export const schemaDict = {
             },
             contentFormat: {
               type: 'string',
-              enum: ['markdown'],
+              knownValues: ['markdown'],
               description: "Content format. Defaults to 'markdown' if omitted.",
             },
             community: {
@@ -460,7 +460,7 @@ export const schemaDict = {
             },
             contentFormat: {
               type: 'string',
-              enum: ['markdown'],
+              knownValues: ['markdown'],
               description: "Content format. Defaults to 'markdown' if omitted.",
             },
             root: {

--- a/src/generated/types/forum/barazo/actor/preferences.ts
+++ b/src/generated/types/forum/barazo/actor/preferences.ts
@@ -17,7 +17,7 @@ const id = 'forum.barazo.actor.preferences'
 export interface Main {
   $type: 'forum.barazo.actor.preferences'
   /** Maximum maturity tier to show. Default: 'safe'. */
-  maturityLevel: 'safe' | 'mature' | 'all'
+  maturityLevel: 'safe' | 'mature' | 'all' | (string & {})
   /** Global muted words (apply to all communities). */
   mutedWords?: string[]
   /** Blocked accounts (content hidden everywhere). */

--- a/src/generated/types/forum/barazo/topic/post.ts
+++ b/src/generated/types/forum/barazo/topic/post.ts
@@ -22,7 +22,7 @@ export interface Main {
   /** Topic body in markdown. */
   content: string
   /** Content format. Defaults to 'markdown' if omitted. */
-  contentFormat?: 'markdown'
+  contentFormat?: 'markdown' | (string & {})
   /** DID of the community where this record was created. Immutable origin identifier for cross-community attribution. */
   community: string
   /** Category rkey within the community. */

--- a/src/generated/types/forum/barazo/topic/reply.ts
+++ b/src/generated/types/forum/barazo/topic/reply.ts
@@ -21,7 +21,7 @@ export interface Main {
   /** Reply body in markdown. */
   content: string
   /** Content format. Defaults to 'markdown' if omitted. */
-  contentFormat?: 'markdown'
+  contentFormat?: 'markdown' | (string & {})
   root: ComAtprotoRepoStrongRef.Main
   parent: ComAtprotoRepoStrongRef.Main
   /** DID of the community where this reply was created. Immutable origin identifier. */

--- a/tests/lexicon-schemas.test.ts
+++ b/tests/lexicon-schemas.test.ts
@@ -241,13 +241,13 @@ describe('forum.barazo.actor.preferences lexicon', () => {
     expect(main['key']).toBe('literal:self')
   })
 
-  it('has maturityLevel enum with safe, mature, all', () => {
+  it('has maturityLevel knownValues with safe, mature, all', () => {
     const defs = schema['defs'] as Record<string, unknown>
     const main = defs['main'] as Record<string, unknown>
     const record = main['record'] as Record<string, unknown>
     const props = record['properties'] as Record<string, unknown>
     const ml = props['maturityLevel'] as Record<string, unknown>
-    expect(ml['enum']).toEqual(['safe', 'mature', 'all'])
+    expect(ml['knownValues']).toEqual(['safe', 'mature', 'all'])
   })
 
   it('defines crossPostConfig as a separate def', () => {


### PR DESCRIPTION
## Summary

- Changes `contentFormat` from `enum` to `knownValues` in `post.json` and `reply.json`
- Changes `maturityLevel` from `enum` to `knownValues` in `preferences.json`
- Regenerates TypeScript types (closed string unions become open `| (string & {})`)
- Updates test assertion from `enum` to `knownValues`

## Why

AT Protocol `enum` is a **closed set** -- validators reject unknown values. This means adding a new content format (e.g., `plaintext`, `richtext`) or maturity level would be a breaking change for any PDS or AppView already validating against the current schema.

`knownValues` is an **open set** -- it suggests common values but accepts any string. This follows the AT Protocol convention used by `community.lexicon.calendar.rsvp` and other ecosystem lexicons.

This is a **critical forward-compatibility fix** that must land before any records are written to PDSs.

## Test plan

- [x] All 135 tests pass (`npm test`)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Pre-commit hooks pass

Fixes barazo-forum/barazo-workspace#24