### PR TITLE
refactor(validation): consolidate didRegex into shared patterns module

### DIFF
--- a/src/validation/actor-preferences.ts
+++ b/src/validation/actor-preferences.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
-
-const didRegex = /^did:[a-z]+:[a-zA-Z0-9._:%-]+$/
+import { didRegex } from './patterns.js'
 
 /** Cross-post configuration for new topics. */
 export const crossPostConfigSchema = z.object({

--- a/src/validation/patterns.ts
+++ b/src/validation/patterns.ts
@@ -1,0 +1,2 @@
+/** DID format regex (simplified, catches obvious malformed DIDs). */
+export const didRegex = /^did:[a-z]+:[a-zA-Z0-9._:%-]+$/

--- a/src/validation/reaction.ts
+++ b/src/validation/reaction.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import { strongRefSchema } from './strong-ref.js'
-
-const didRegex = /^did:[a-z]+:[a-zA-Z0-9._:%-]+$/
+import { didRegex } from './patterns.js'
 
 /**
  * Zod schema for forum.barazo.interaction.reaction records.

--- a/src/validation/topic-post.ts
+++ b/src/validation/topic-post.ts
@@ -1,9 +1,7 @@
 import { z } from 'zod'
 import { selfLabelsSchema } from './self-labels.js'
 import { facetSchema } from './facet.js'
-
-/** DID format regex (simplified, catches obvious malformed DIDs). */
-const didRegex = /^did:[a-z]+:[a-zA-Z0-9._:%-]+$/
+import { didRegex } from './patterns.js'
 
 /**
  * Zod schema for forum.barazo.topic.post records.

--- a/src/validation/topic-reply.ts
+++ b/src/validation/topic-reply.ts
@@ -2,8 +2,7 @@ import { z } from 'zod'
 import { strongRefSchema } from './strong-ref.js'
 import { selfLabelsSchema } from './self-labels.js'
 import { facetSchema } from './facet.js'
-
-const didRegex = /^did:[a-z]+:[a-zA-Z0-9._:%-]+$/
+import { didRegex } from './patterns.js'
 
 /**
  * Zod schema for forum.barazo.topic.reply records.

--- a/src/validation/vote.ts
+++ b/src/validation/vote.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import { strongRefSchema } from './strong-ref.js'
-
-const didRegex = /^did:[a-z]+:[a-zA-Z0-9._:%-]+$/
+import { didRegex } from './patterns.js'
 
 /**
  * Zod schema for forum.barazo.interaction.vote records.


### PR DESCRIPTION
## Summary
- Extract duplicated `didRegex` from 5 validation files into a single `patterns.ts` module
- All validation schemas now import from the canonical source

## Changes
- `src/validation/patterns.ts`: new file exporting `didRegex`
- `src/validation/topic-post.ts`: import from patterns.ts
- `src/validation/topic-reply.ts`: import from patterns.ts
- `src/validation/reaction.ts`: import from patterns.ts
- `src/validation/vote.ts`: import from patterns.ts
- `src/validation/actor-preferences.ts`: import from patterns.ts

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes (175 tests)
- [ ] CI passes (lint, typecheck, build, tests)