### PR TITLE
chore(ci): add pnpm cache, concurrency, and frozen-lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,9 +26,10 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm lint


### PR DESCRIPTION
## Summary
- Add `concurrency` group with `cancel-in-progress: true` to CI workflow
- Add `cache: 'pnpm'` to `setup-node` step for faster CI runs
- Use `--frozen-lockfile` for reproducible installs

## Context
Part of cross-repo CI standardization. Aligns barazo-lexicons CI with barazo-web patterns.

## Test plan
- [ ] CI passes: lint, typecheck, test, build
- [ ] pnpm cache is populated and reused on subsequent runs