### PR TITLE
ci(tangled): mirror main to Tangled

### DIFF
--- a/.github/workflows/tangled-mirror.yml
+++ b/.github/workflows/tangled-mirror.yml
@@ -1,0 +1,32 @@
+name: Mirror to Tangled
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.TANGLED_SSH_KEY }}" > ~/.ssh/tangled
+          chmod 600 ~/.ssh/tangled
+          cat >> ~/.ssh/config <<EOF
+          Host tangled.org
+            Hostname tangled.org
+            User git
+            IdentityFile ~/.ssh/tangled
+            StrictHostKeyChecking accept-new
+            AddressFamily inet
+          EOF
+
+      - name: Push to Tangled
+        run: |
+          git remote add tangled git@tangled.org:gui.do/${{ github.event.repository.name }}
+          git push tangled main --force


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to push `main` to [tangled.org/gui.do/barazo-lexicons](https://tangled.org/gui.do/barazo-lexicons) on every merge
- Makes Barazo visible in the AT Protocol developer ecosystem
- Uses org-level `TANGLED_SSH_KEY` secret for authentication

## Test plan
- [ ] Merge PR and verify the workflow runs successfully
- [ ] Check https://tangled.org/gui.do/barazo-lexicons shows updated code