### PR TITLE
docs(agents): update tagline, add actor.preferences to MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Lexicon schemas for the Barazo forum platform. Defines all `forum.barazo.*` reco
 - `forum.barazo.topic.post` -- main thread posts
 - `forum.barazo.topic.reply` -- replies to threads
 - `forum.barazo.interaction.reaction` -- reactions (configurable per forum)
+- `forum.barazo.actor.preferences` -- per-user preferences (singleton record)
 
 Categories are AppView-only (admin-managed, stored in PostgreSQL), not PDS records.
 
@@ -39,7 +40,7 @@ Categories are AppView-only (admin-managed, stored in PostgreSQL), not PDS recor
 
 ### About Barazo
 
-Federated forum built on the [AT Protocol](https://atproto.com/). Portable identity, user-owned data, cross-community reputation.
+Open-source forum software built on the [AT Protocol](https://atproto.com/). Portable identity, member-owned data, no lock-in.
 
 - **Organization:** [github.com/barazo-forum](https://github.com/barazo-forum)
 - **License:** AGPL-3.0 (backend) / MIT (frontend, lexicons, deploy, website)


### PR DESCRIPTION
## Summary
- Update shared tagline to brand-aligned version: "Open-source forum software... member-owned data, no lock-in."
- Add `forum.barazo.actor.preferences` to Core Record Types (MVP) list

Part of pre-P3 documentation audit (B1, S8).

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm actor.preferences appears in MVP list