### PR TITLE
fix(lexicons): bump tag limit from 5 to 25

### DIFF
--- a/lexicons/forum/barazo/topic/post.json
+++ b/lexicons/forum/barazo/topic/post.json
@@ -43,7 +43,7 @@
           },
           "tags": {
             "type": "array",
-            "maxLength": 5,
+            "maxLength": 25,
             "items": {
               "type": "string",
               "minLength": 1,

--- a/src/generated/lexicons.ts
+++ b/src/generated/lexicons.ts
@@ -566,7 +566,7 @@ export const schemaDict = {
             },
             tags: {
               type: 'array',
-              maxLength: 5,
+              maxLength: 25,
               items: {
                 type: 'string',
                 minLength: 1,

--- a/src/validation/topic-post.ts
+++ b/src/validation/topic-post.ts
@@ -18,7 +18,7 @@ export const topicPostSchema = z.object({
   contentFormat: z.literal('markdown').optional(),
   community: z.string().regex(didRegex),
   category: z.string().regex(recordKeyRegex).max(640),
-  tags: z.array(z.string().min(1).max(300)).max(5).optional(),
+  tags: z.array(z.string().min(1).max(300)).max(25).optional(),
   facets: z.array(facetSchema).optional(),
   langs: z.array(z.string().min(1)).max(3).optional(),
   labels: selfLabelsSchema.optional(),

--- a/tests/lexicon-schemas.test.ts
+++ b/tests/lexicon-schemas.test.ts
@@ -118,7 +118,7 @@ describe('forum.barazo.topic.post lexicon', () => {
     expect(category['maxGraphemes']).toBe(64)
   })
 
-  it('tags is optional with max 5 items', () => {
+  it('tags is optional with max 25 items', () => {
     const defs = schema['defs'] as Record<string, unknown>
     const main = defs['main'] as Record<string, unknown>
     const record = main['record'] as Record<string, unknown>
@@ -126,7 +126,7 @@ describe('forum.barazo.topic.post lexicon', () => {
     expect(required).not.toContain('tags')
     const props = record['properties'] as Record<string, unknown>
     const tags = props['tags'] as Record<string, unknown>
-    expect(tags['maxLength']).toBe(5)
+    expect(tags['maxLength']).toBe(25)
   })
 
   it('has optional facets array referencing app.bsky.richtext.facet', () => {

--- a/tests/zod-validation.test.ts
+++ b/tests/zod-validation.test.ts
@@ -67,10 +67,10 @@ describe('topicPostSchema', () => {
     expect(topicPostSchema.safeParse({ ...validPost, community: 'not-a-did' }).success).toBe(false)
   })
 
-  it('rejects more than 5 tags', () => {
+  it('rejects more than 25 tags', () => {
     const tooManyTags = {
       ...validPost,
-      tags: ['a', 'b', 'c', 'd', 'e', 'f'],
+      tags: Array.from({ length: 26 }, (_, i) => `tag-${String(i)}`),
     }
     expect(topicPostSchema.safeParse(tooManyTags).success).toBe(false)
   })


### PR DESCRIPTION
## Summary

- Increases `maxLength` on `tags` array from 5 to 25 in `forum.barazo.topic.post`
- Updates Zod validation, generated types, and tests to match

The original limit of 5 was conservative without a strong technical reason. PDS record size is generous and tags are tiny strings. The UI layer can control how many to display; the lexicon shouldn't be the gatekeeper.

## Context

Community feedback: https://discourse.atprotocol.community/t/624/4

## Test plan

- [x] All 189 existing tests pass
- [x] Lexicon schema test updated to expect maxLength 25
- [x] Zod validation test updated to reject 26 tags (was 6)
- [x] Lint and prettier pass