### PR TITLE
ci(lexicons): add job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
   check:
     name: Lint, Typecheck, Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 10` to the `check` job to replace GitHub's default 6-hour timeout
- Prevents runaway builds from consuming runner minutes

Part of cross-repo CI pipeline optimization (Phase 1).

## Test plan
- [ ] CI passes on this PR
- [ ] Verify timeout appears in workflow YAML via Actions tab